### PR TITLE
Removing never used bool return type on safeOpenURL

### DIFF
--- a/NStackSDK/NStackSDK/Classes/Notify/AlertManager.swift
+++ b/NStackSDK/NStackSDK/Classes/Notify/AlertManager.swift
@@ -129,7 +129,7 @@ public class AlertManager {
             self.repository.markNewerVersionAsSeen(version.lastId, appStoreButtonPressed: didPressAppStore)
             if didPressAppStore {
                 if let link = version.link {
-                    _ = UIApplication.safeSharedApplication()?.safeOpenURL(link)
+                    UIApplication.safeSharedApplication()?.safeOpenURL(link)
                 }
             }
         }
@@ -180,7 +180,7 @@ public class AlertManager {
             self.repository.markRateReminderAsSeen(result)
 
             if result == .Rate, let link = rateReminder.link {
-                _ = UIApplication.safeSharedApplication()?.safeOpenURL(link)
+                UIApplication.safeSharedApplication()?.safeOpenURL(link)
             }
         }
 

--- a/NStackSDK/NStackSDK/Classes/Other/UIApplication+SafeExtensions.swift
+++ b/NStackSDK/NStackSDK/Classes/Other/UIApplication+SafeExtensions.swift
@@ -21,15 +21,12 @@ extension UIApplication {
         return unmanagedSharedApplication.takeRetainedValue() as? UIApplication
     }
 
-    func safeOpenURL(_ url: URL) -> Bool {
-        guard self.canOpenURL(url) else { return false }
+    func safeOpenURL(_ url: URL) {
+        guard self.canOpenURL(url) else { return }
 
-        guard let returnVal = self.perform(NSSelectorFromString("openURL:"), with: url) else {
-            return false
+        guard let _ = self.perform(NSSelectorFromString("openURL:"), with: url) else {
+            return
         }
-
-        let value = returnVal.takeRetainedValue() as? NSNumber
-        return value?.boolValue ?? false
     }
 }
 


### PR DESCRIPTION
A suggestion to remove the return on safeOpenURL - which is not used anyway and has been causing problems for some time.
Im aware that a more optimal solution would be to keep the return type and resolve the cause of the crash discussed in https://github.com/nodes-ios/NStackSDK/issues/42 but this solves it to :)