### PR TITLE
Keep showing update alert (also non force) until the user has updated to required version

### DIFF
--- a/NStackSDK/NStackSDK/Classes/NStack Manager/ConnectionManager.swift
+++ b/NStackSDK/NStackSDK/Classes/NStack Manager/ConnectionManager.swift
@@ -141,18 +141,6 @@ extension ConnectionManager: UpdatesRepository {
 }
 
 extension ConnectionManager: VersionsRepository {
-    func markNewerVersionAsSeen(_ id: Int, appStoreButtonPressed:Bool) {
-        let params: [String : Any] = [
-            "guid"              : Configuration.guid,
-            "update_id"         : id,
-            "answer"            : (appStoreButtonPressed ? "yes" : "no"),
-            "type"              : "newer_version"
-        ]
-
-        let url = baseURL + "notify/updates/views"
-        manager.request(url, method: .post, parameters:params, headers: defaultHeaders)
-    }
-
     func markWhatsNewAsSeen(_ id: Int) {
         let params: [String : Any] = [
             "guid"              : Configuration.guid,

--- a/NStackSDK/NStackSDK/Classes/Notify/AlertManager.swift
+++ b/NStackSDK/NStackSDK/Classes/Notify/AlertManager.swift
@@ -126,9 +126,7 @@ public class AlertManager {
     internal func showUpdateAlert(newVersion version:Update.Version) {
 
         let appStoreCompletion = { (didPressAppStore:Bool) -> Void in
-            if version.state != .Force {
-                self.repository.markNewerVersionAsSeen(version.lastId, appStoreButtonPressed: didPressAppStore)
-            }
+            
             if didPressAppStore {
                 if let link = version.link {
                     UIApplication.safeSharedApplication()?.safeOpenURL(link)

--- a/NStackSDK/NStackSDK/Classes/Repository/Repository.swift
+++ b/NStackSDK/NStackSDK/Classes/Repository/Repository.swift
@@ -44,7 +44,6 @@ protocol GeographyRepository {
 // MARK: - Versions -
 
 protocol VersionsRepository {
-    func markNewerVersionAsSeen(_ id: Int, appStoreButtonPressed: Bool)
     func markWhatsNewAsSeen(_ id: Int)
     func markMessageAsRead(_ id: String)
 


### PR DESCRIPTION
This is done by removing call to notify/updates/views from the update alert completion block.