### PR TITLE
Redone the way we match for correct language 

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Alamofire/Alamofire" "4.3.0"
+github "Alamofire/Alamofire" "4.4.0"
 github "nodes-ios/Cashier" "1.2.1"
-github "nodes-ios/Serpent" "1.0.4"
+github "nodes-ios/Serpent" "1.0.5"

--- a/NStackSDK/NStackSDK.xcodeproj/project.pbxproj
+++ b/NStackSDK/NStackSDK.xcodeproj/project.pbxproj
@@ -33,7 +33,6 @@
 		01A3344F1E4E825E003CE9BA /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A334481E4E825E003CE9BA /* Extensions.swift */; };
 		01A334501E4E825E003CE9BA /* UIApplication+SafeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A334491E4E825E003CE9BA /* UIApplication+SafeExtensions.swift */; };
 		01A334511E4E825E003CE9BA /* UIApplication+SafeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A334491E4E825E003CE9BA /* UIApplication+SafeExtensions.swift */; };
-		01A3349B1E4F205E003CE9BA /* NStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 30A3D84A1B9DB94100C2D15C /* NStack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		01A3347C1E4F1B43003CE9BA /* AppOpenResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CB55491C8DEAC200389D2B /* AppOpenResponse.swift */; };
 		01A3347D1E4F1B43003CE9BA /* LanguageData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CB554A1C8DEAC200389D2B /* LanguageData.swift */; };
 		01A3347E1E4F1B43003CE9BA /* AppOpenData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 304C42811BA0745500AE3D6F /* AppOpenData.swift */; };
@@ -64,10 +63,14 @@
 		01A334981E4F1B97003CE9BA /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E3B654531E00481300FC9380 /* Alamofire.framework */; };
 		01A334991E4F1B99003CE9BA /* Cashier.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E3B654551E00481300FC9380 /* Cashier.framework */; };
 		01A3349A1E4F1B9B003CE9BA /* Serpent.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E3B654591E00481300FC9380 /* Serpent.framework */; };
+		01A3349B1E4F205E003CE9BA /* NStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 30A3D84A1B9DB94100C2D15C /* NStack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		01B5BA271D5E02D7006EA3D7 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01B5BA261D5E02D7006EA3D7 /* UIKit.framework */; };
 		01B5BA291D5E02DD006EA3D7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01B5BA281D5E02DD006EA3D7 /* Foundation.framework */; };
 		01BBEFAE1DE0FC66003AC718 /* Country.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839497BE1DC21DBF007FE281 /* Country.swift */; };
 		01BBEFAF1DE0FC66003AC718 /* Timezone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839497C01DC21ED2007FE281 /* Timezone.swift */; };
+		01C979E41EA8EB98001D8DBF /* BackendSelectedLanguageTranslations.json in Resources */ = {isa = PBXBuildFile; fileRef = 01C979E31EA8EB98001D8DBF /* BackendSelectedLanguageTranslations.json */; };
+		01C979E51EA8EB98001D8DBF /* BackendSelectedLanguageTranslations.json in Resources */ = {isa = PBXBuildFile; fileRef = 01C979E31EA8EB98001D8DBF /* BackendSelectedLanguageTranslations.json */; };
+		01C979E61EA8EB98001D8DBF /* BackendSelectedLanguageTranslations.json in Resources */ = {isa = PBXBuildFile; fileRef = 01C979E31EA8EB98001D8DBF /* BackendSelectedLanguageTranslations.json */; };
 		01D4EDE91D5DF17800E7E94C /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D4EDE81D5DF17800E7E94C /* Configuration.swift */; };
 		01DA43191C7904E200D0FC04 /* NStack.plist in Resources */ = {isa = PBXBuildFile; fileRef = 01DA43141C7904E200D0FC04 /* NStack.plist */; };
 		01DA431B1C7904E200D0FC04 /* Translations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DA43171C7904E200D0FC04 /* Translations.swift */; };
@@ -233,6 +236,7 @@
 		01A334741E4F1B2A003CE9BA /* NStackSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NStackSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		01B5BA261D5E02D7006EA3D7 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		01B5BA281D5E02DD006EA3D7 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		01C979E31EA8EB98001D8DBF /* BackendSelectedLanguageTranslations.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = BackendSelectedLanguageTranslations.json; sourceTree = "<group>"; };
 		01D4EDE81D5DF17800E7E94C /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Configuration.swift; path = Classes/Model/Configuration.swift; sourceTree = "<group>"; };
 		01DA43131C7904E200D0FC04 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		01DA43141C7904E200D0FC04 /* NStack.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = NStack.plist; sourceTree = "<group>"; };
@@ -415,6 +419,7 @@
 				E3DC93F81E0195BA00FC9693 /* EmptyLanguageMetaTranslations.json */,
 				01FC667A1DFADC35001682AA /* InvalidTranslations.json */,
 				E3DC93F61E01935400FC9693 /* EmptyTranslations.json */,
+				01C979E31EA8EB98001D8DBF /* BackendSelectedLanguageTranslations.json */,
 				0106ADA21C7914B700E0C8BC /* Translations.json */,
 				01DA43171C7904E200D0FC04 /* Translations.swift */,
 			);
@@ -864,6 +869,7 @@
 				E3DC93F91E0195BA00FC9693 /* EmptyLanguageMetaTranslations.json in Resources */,
 				01FC667B1DFADC35001682AA /* InvalidTranslations.json in Resources */,
 				E3DC93F71E01935400FC9693 /* EmptyTranslations.json in Resources */,
+				01C979E41EA8EB98001D8DBF /* BackendSelectedLanguageTranslations.json in Resources */,
 				01FC667D1DFADEC5001682AA /* WrongTypeTranslations.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -884,6 +890,7 @@
 				E3DC93FA1E0195BA00FC9693 /* EmptyLanguageMetaTranslations.json in Resources */,
 				E3DC93FB1E0195D500FC9693 /* EmptyTranslations.json in Resources */,
 				01F4C6B31DFF72660050D0F1 /* NStack.plist in Resources */,
+				01C979E51EA8EB98001D8DBF /* BackendSelectedLanguageTranslations.json in Resources */,
 				01F4C6B11DFF72620050D0F1 /* Translations.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -904,6 +911,7 @@
 				01A334401E4E7E1C003CE9BA /* EmptyLanguageMetaTranslations.json in Resources */,
 				01A334411E4E7E21003CE9BA /* EmptyTranslations.json in Resources */,
 				E3B654C11E0064B200FC9380 /* InvalidTranslations.json in Resources */,
+				01C979E61EA8EB98001D8DBF /* BackendSelectedLanguageTranslations.json in Resources */,
 				E3B654C21E0064B200FC9380 /* Translations.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1587,6 +1595,7 @@
 				01A3347A1E4F1B2B003CE9BA /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		30A3D8411B9DB94100C2D15C /* Build configuration list for PBXProject "NStackSDK" */ = {
 			isa = XCConfigurationList;

--- a/NStackSDK/NStackSDKTests/Resources/Translations Class/BackendSelectedLanguageTranslations.json
+++ b/NStackSDK/NStackSDKTests/Resources/Translations Class/BackendSelectedLanguageTranslations.json
@@ -1,0 +1,23 @@
+{
+    "data" : {
+        "en-GB" : {
+            "default" : {
+                "successKey" : "Success"
+            }
+        },
+        "en-US" : {
+            "default" : {
+                "successKey" : "Whatever"
+            }
+        }
+    },
+    "meta" : {
+        "is_cached" : false,
+        "language" : {
+            "locale" : "en-US",
+            "id" : 8,
+            "name" : "English (US)",
+            "direction" : "LRM"
+        }
+    }
+}

--- a/NStackSDK/NStackSDKTests/TranslationManagerTests.swift
+++ b/NStackSDK/NStackSDKTests/TranslationManagerTests.swift
@@ -93,7 +93,7 @@ class TranslationManagerTests: XCTestCase {
         // Stop logger logging before teardown
         logger.logLevel = .none
 
-        manager.persistedTranslations = nil
+        manager.clearTranslations(includingPersisted: true)
         manager = nil
         repositoryMock = nil
         fileManagerMock = nil
@@ -284,8 +284,10 @@ class TranslationManagerTests: XCTestCase {
         // Instead of falling to any type of english or first in the array.
         //
         // In the JSON backends return US english as most appropriate.
+        manager.clearTranslations(includingPersisted: true)
         repositoryMock.preferredLanguages = ["da-DK"]
         mockBundle.resourcePathOverride = backendSelectedTranslationsJSONPath
+        repositoryMock.customBundles = [mockBundle]
         XCTAssertEqual(testTranslations.defaultSection.successKey, "Whatever")
     }
     

--- a/NStackSDK/NStackSDKTests/TranslationManagerTests.swift
+++ b/NStackSDK/NStackSDKTests/TranslationManagerTests.swift
@@ -101,16 +101,16 @@ class TranslationManagerTests: XCTestCase {
     }
 
     // MARK: - Loading -
-
+    
     func testLoadTranslations() {
         XCTAssertNil(manager.translationsObject)
         manager.loadTranslations()
         XCTAssertNotNil(manager.translationsObject,
                         "Translations object shouldn't be nil after loading.")
     }
-
+    
     // MARK: - Update -
-
+    
     func testUpdateSuccess() {
         repositoryMock.translationsResponse = mockWrappedTranslations
         XCTAssertNil(manager.synchronousUpdateTranslations(), "Error should be nil.")
@@ -119,7 +119,7 @@ class TranslationManagerTests: XCTestCase {
         XCTAssertNotNil(manager.persistedTranslations,
                         "Persistent translations should be saved after successful update.")
     }
-
+    
     func testUpdateFailure() {
         repositoryMock.translationsResponse = nil
         XCTAssertNotNil(manager.synchronousUpdateTranslations(), "Error shouldn't be nil.")
@@ -128,12 +128,12 @@ class TranslationManagerTests: XCTestCase {
         XCTAssertNil(manager.persistedTranslations,
                      "Persistent translations should not be saved after failed update.")
     }
-
+    
     // MARK: - Translation for key
     
     func testTranslationForKeyFailure() {
         repositoryMock.preferredLanguages = [mockLanguage.locale]
-        XCTAssertNotEqual(manager.translationString(keyPath: "default.successKey"), "Success")
+        XCTAssertNotEqual(manager.translationString(keyPath: "default.successKey"), "NoSuccess")
     }
     
     func testTranslationForWrongKeyFailure() {
@@ -152,7 +152,7 @@ class TranslationManagerTests: XCTestCase {
     }
     
     // MARK: - Fetch -
-
+    
     func testFetchCurrentLanguageSuccess() {
         repositoryMock.currentLanguage = mockLanguage
         let exp = expectation(description: "Fetch language should return one language.")
@@ -162,12 +162,12 @@ class TranslationManagerTests: XCTestCase {
             } else {
                 XCTAssert(false)
             }
-
+            
             exp.fulfill()
         }
         waitForExpectations(timeout: 5, handler: nil)
     }
-
+    
     func testFetchCurrentLanguageFailure() {
         repositoryMock.currentLanguage = nil
         let exp = expectation(description: "Fetch language should fail without language.")
@@ -179,7 +179,7 @@ class TranslationManagerTests: XCTestCase {
         }
         waitForExpectations(timeout: 5, handler: nil)
     }
-
+    
     func testFetchAvailableLanguagesSuccess() {
         repositoryMock.availableLanguages = [
             Language(id: 0, name: "English", locale: "en-GB",
@@ -187,7 +187,7 @@ class TranslationManagerTests: XCTestCase {
             Language(id: 1, name: "Danish", locale: "da-DK",
                      direction: "LRM", acceptLanguage: "da-DK")
         ]
-
+        
         let exp = expectation(description: "Fetch available should return two languages.")
         manager.fetchAvailableLanguages { (response) in
             if case .failure(_) = response.result {
@@ -197,7 +197,7 @@ class TranslationManagerTests: XCTestCase {
         }
         waitForExpectations(timeout: 5, handler: nil)
     }
-
+    
     func testFetchAvailableLanguagesFailure() {
         repositoryMock.availableLanguages = nil
         let exp = expectation(description: "Fetch available should fail without languages.")
@@ -209,30 +209,30 @@ class TranslationManagerTests: XCTestCase {
         }
         waitForExpectations(timeout: 5, handler: nil)
     }
-
+    
     // MARK: - Accept -
-
+    
     func testAcceptLanguage() {
         // Test simple language
         repositoryMock.preferredLanguages = ["en"]
         XCTAssertEqual(manager.acceptLanguage, "en;q=1.0")
-
+        
         // Test two languages with locale
         repositoryMock.preferredLanguages = ["da-DK", "en-GB"]
         XCTAssertEqual(manager.acceptLanguage, "da-DK;q=1.0,en-GB;q=0.9")
-
+        
         // Test max lang limit
         repositoryMock.preferredLanguages = ["da-DK", "en-GB", "en", "cs-CZ", "sk-SK", "no-NO"]
         XCTAssertEqual(manager.acceptLanguage,
                        "da-DK;q=1.0,en-GB;q=0.9,en;q=0.8,cs-CZ;q=0.7,sk-SK;q=0.6",
                        "There should be maximum 5 accept languages.")
-
+        
         // Test fallback
         repositoryMock.preferredLanguages = []
         XCTAssertEqual(manager.acceptLanguage, "en;q=1.0",
                        "If no accept language there should be fallback to english.")
     }
-
+    
     func testLastAcceptHeader() {
         XCTAssertNil(manager.lastAcceptHeader, "Last accept header should be nil at start.")
         manager.lastAcceptHeader = "da-DK;q=1.0,en;q=1.0"
@@ -240,15 +240,15 @@ class TranslationManagerTests: XCTestCase {
         manager.lastAcceptHeader = nil
         XCTAssertNil(manager.lastAcceptHeader, "Last accept header should be nil.")
     }
-
+    
     // MARK: - Language Override -
-
+    
     func testLanguageOverride() {
         XCTAssertEqual(testTranslations.defaultSection.successKey, "Success")
         manager.languageOverride = mockLanguage
         XCTAssertEqual(testTranslations.defaultSection.successKey, "Fedt")
     }
-
+    
     func testLanguageOverrideStore() {
         XCTAssertNil(manager.languageOverride, "Language override should be nil at start.")
         manager.languageOverride = mockLanguage
@@ -256,35 +256,35 @@ class TranslationManagerTests: XCTestCase {
         manager.languageOverride = nil
         XCTAssertNil(manager.languageOverride, "Language override should be nil.")
     }
-
+    
     func testLanguageOverrideClearTranslations() {
         // Load translations
         manager.loadTranslations()
         XCTAssertNotNil(manager.translationsObject,
                         "Translations shouldn't be nil after loading.")
-
+        
         // Override lang, should clear all loaded
         manager.languageOverride = mockLanguage
         XCTAssertNil(manager.translationsObject,
                      "Translations should be cleared if language is overriden.")
-
+        
         // Accessing again should load with override lang
         _ = manager.translations() as Translations
         XCTAssertNotNil(manager.translationsObject,
                         "Translations should load with language override.")
     }
-
+    
     // MARK: - Translations -
-
+    
     func testTranslationsMemoryCache() {
         XCTAssertNil(manager.translationsObject)
         XCTAssertEqual(testTranslations.defaultSection.successKey, "Success")
         XCTAssertNotNil(manager.translationsObject)
         XCTAssertEqual(testTranslations.defaultSection.successKey, "Success")
     }
-
+    
     // MARK: - Translation Dictionaries -
-
+    
     func testPersistedTranslations() {
         XCTAssertNil(manager.persistedTranslations, "Persisted translations should be nil at start.")
         manager.persistedTranslations = mockTranslations.translations
@@ -292,38 +292,38 @@ class TranslationManagerTests: XCTestCase {
         manager.persistedTranslations = nil
         XCTAssertNil(manager.persistedTranslations, "Persisted translations should be nil.")
     }
-
+    
     func testPersistedTranslationsSaveFailure() {
         fileManagerMock.searchPathUrlsOverride = []
         XCTAssertNil(manager.persistedTranslations, "Persisted translations should be nil at start.")
         manager.persistedTranslations = mockTranslations.translations
         XCTAssertNil(manager.persistedTranslations, "There shouldn't be any saved translations.")
     }
-
+    
     func testPersistedTranslationsSaveFailureBadUrl() {
         fileManagerMock.searchPathUrlsOverride = [URL(string: "test://")!]
         XCTAssertNil(manager.persistedTranslations, "Persisted translations should be nil at start.")
         manager.persistedTranslations = mockTranslations.translations
         XCTAssertNil(manager.persistedTranslations, "There shouldn't be any saved translations.")
     }
-
+    
     func testPersistedTranslationsOnUpdate() {
         repositoryMock.translationsResponse = mockWrappedTranslations
         XCTAssertNil(manager.synchronousUpdateTranslations(), "No error should happen on update.")
         XCTAssertNotNil(manager.persistedTranslations, "Persisted translations should be available.")
     }
-
+    
     func testFallbackTranslations() {
         XCTAssertNotNil(manager.fallbackTranslations, "Fallback translations should be available.")
     }
-
+    
     func testFallbackTranslationsInvalidPath() {
         let bundle = mockBundle
         bundle.resourcePathOverride = "file://BlaBlaBla.json" // invalid path
         repositoryMock.customBundles = [bundle]
         XCTAssertNotNil(manager.fallbackTranslations, "Fallback translations should fail with invalid path.")
     }
-
+    
     func testFallbackTranslationsInvalidJSON() {
         let bundle = mockBundle
         bundle.resourcePathOverride = invalidTranslationsJSONPath // invalid json file
@@ -337,7 +337,7 @@ class TranslationManagerTests: XCTestCase {
         repositoryMock.customBundles = [bundle]
         XCTAssertNotNil(manager.loadTranslations(), "Fallback translations should fail with invalid JSON.")
     }
-
+    
     func testFallbackTranslationsEmptyLanguageJSON() {
         let bundle = mockBundle
         bundle.resourcePathOverride = emptyLanguageMetaTranslationsJSONPath// empty meta laguage file
@@ -351,27 +351,27 @@ class TranslationManagerTests: XCTestCase {
         repositoryMock.customBundles = [bundle]
         XCTAssertNotNil(manager.fallbackTranslations, "Fallback translations should fail with wrong format JSON.")
     }
-
+    
     // MARK: - Unwrap & Parse -
-
+    
     func testUnwrapAndParse() {
-        repositoryMock.preferredLanguages = ["da"]
+        repositoryMock.preferredLanguages = ["en"]
         let final = manager.processAllTranslations(mockWrappedTranslations.translations!)
         XCTAssertNotNil(final, "Unwrap and parse should succeed.")
-        XCTAssertEqual(final?.value(forKeyPath: "default.successKey") as? String, Optional("FedtUpdated"))
+        XCTAssertEqual(final?.value(forKeyPath: "default.successKey") as? String, Optional("SuccessUpdated"))
     }
-
+    
     // MARK: - Extraction -
-
+    
     func testExtractWithFullLocale() {
         repositoryMock.preferredLanguages = ["en-GB", "da-DK"]
-        let lang: NSDictionary = ["da-DK" : ["correct" : "no"],
-                                  "en-GB" : ["correct" : "yes"]]
+        let lang: NSDictionary = ["en-GB" : ["correct" : "yes"],
+                                  "da-DK" : ["correct" : "no"]]
         let dict = manager.extractLanguageDictionary(fromDictionary: lang)
         XCTAssertNotNil(dict)
         XCTAssertEqual(dict.value(forKey: "correct") as? String, Optional("yes"))
     }
-
+    
     func testExtractWithShortLocale() {
         repositoryMock.preferredLanguages = ["da"]
         let lang: NSDictionary = ["da-DK" : ["correct" : "yes"],
@@ -380,7 +380,7 @@ class TranslationManagerTests: XCTestCase {
         XCTAssertNotNil(dict)
         XCTAssertEqual(dict.value(forKey: "correct") as? String, Optional("yes"))
     }
-
+    
     func testExtractWithLanguageOverride() {
         repositoryMock.preferredLanguages = ["en-GB", "en"]
         manager.languageOverride = mockLanguage
@@ -390,7 +390,7 @@ class TranslationManagerTests: XCTestCase {
         XCTAssertNotNil(dict)
         XCTAssertEqual(dict.value(forKey: "correct") as? String, Optional("yes"))
     }
-
+    
     func testExtractWithWrongLanguageOverride() {
         repositoryMock.preferredLanguages = ["en-GB", "en"]
         manager.languageOverride = mockLanguage
@@ -399,25 +399,37 @@ class TranslationManagerTests: XCTestCase {
         XCTAssertNotNil(dict)
         XCTAssertEqual(dict.value(forKey: "correct") as? String, Optional("yes"))
     }
-
-    func testExtractWithSameRegions() {
-        repositoryMock.preferredLanguages = ["de-DK", "da-DK"]
-        let lang: NSDictionary = ["de-DE" : ["correct" : "yes"],
+    
+    func testExtractWithSameRegionsWithCurrentLanguage() {
+        repositoryMock.preferredLanguages = ["da-DK", "en-DK"]
+        manager.currentLanguage = Language(id: 0, name: "English", locale: "en-UK",
+                                           direction: "lrm", acceptLanguage: "en-UK")
+        let lang: NSDictionary = ["en-AU" : ["correct" : "no"],
+                                  "en-UK" : ["correct" : "yes"]]
+        let dict = manager.extractLanguageDictionary(fromDictionary: lang)
+        XCTAssertNotNil(dict)
+        XCTAssertEqual(dict.value(forKey: "correct") as? String, Optional("yes"))
+    }
+    
+    func testExtractWithNoLocaleButWithCurrentLanguage() {
+        repositoryMock.preferredLanguages = []
+        manager.currentLanguage = mockLanguage
+        let lang: NSDictionary = ["en-GB" : ["correct" : "no"],
+                                  "da-DK" : ["correct" : "yes"]]
+        let dict = manager.extractLanguageDictionary(fromDictionary: lang)
+        XCTAssertNotNil(dict)
+        XCTAssertEqual(dict.value(forKey: "correct") as? String, Optional("yes"))
+    }
+    
+    func testExtractWithNoLocaleAndNoCurrentLanguage() {
+        repositoryMock.preferredLanguages = []
+        let lang: NSDictionary = ["en-GB" : ["correct" : "yes"],
                                   "da-DK" : ["correct" : "no"]]
         let dict = manager.extractLanguageDictionary(fromDictionary: lang)
         XCTAssertNotNil(dict)
         XCTAssertEqual(dict.value(forKey: "correct") as? String, Optional("yes"))
     }
-
-    func testExtractWithNoLocale() {
-        repositoryMock.preferredLanguages = []
-        let lang: NSDictionary = ["da-DK" : ["correct" : "no"],
-                                  "en-GB" : ["correct" : "yes"]]
-        let dict = manager.extractLanguageDictionary(fromDictionary: lang)
-        XCTAssertNotNil(dict)
-        XCTAssertEqual(dict.value(forKey: "correct") as? String, Optional("yes"))
-    }
-
+    
     func testExtractWithNoLocaleAndNoEnglish() {
         repositoryMock.preferredLanguages = []
         let lang: NSDictionary = ["es" : ["correct" : "no"],
@@ -426,7 +438,7 @@ class TranslationManagerTests: XCTestCase {
         XCTAssertNotNil(dict)
         XCTAssertEqual(dict.value(forKey: "correct") as? String, Optional("yes"))
     }
-
+    
     func testExtractFailure() {
         repositoryMock.preferredLanguages = ["da-DK"]
         let lang: NSDictionary = [:]
@@ -434,16 +446,16 @@ class TranslationManagerTests: XCTestCase {
         XCTAssertNotNil(dict)
         XCTAssertEqual(dict.allKeys.count, 0, "Extracted dictionary should not be empty.")
     }
-
+    
     // MARK: - Clearing -
-
+    
     func testClearTranslations() {
         manager.loadTranslations()
         XCTAssertNotNil(manager.translationsObject, "Translations shouldn't be nil.")
         manager.clearTranslations()
         XCTAssertNil(manager.translationsObject, "Translations should not exist after clear.")
     }
-
+    
     func testClearPersistedTranslations() {
         repositoryMock.translationsResponse = mockWrappedTranslations
         XCTAssertNil(manager.synchronousUpdateTranslations())
@@ -459,13 +471,13 @@ extension TranslationManager {
     fileprivate func synchronousUpdateTranslations() -> NStackError.Translations? {
         let semaphore = DispatchSemaphore(value: 0)
         var error: NStackError.Translations?
-
+        
         updateTranslations { e in
             error = e
             semaphore.signal()
         }
         semaphore.wait()
-
+        
         return error
     }
 }


### PR DESCRIPTION
We used to not take into account what the backend told was the best fit language.
This update will use this before trying to match the list of NStack provided languages with the preferred locale.
Please give it a rough review as im not 100% into all the NStack translations use cases.