### PR TITLE
Added Update option to never connection server

### DIFF
--- a/NStackSDK/NStackSDK/Classes/Model/Configuration.swift
+++ b/NStackSDK/NStackSDK/Classes/Model/Configuration.swift
@@ -14,7 +14,8 @@ public struct UpdateOptions: OptionSet {
     public init(rawValue: Int) { self.rawValue = rawValue }
 
     public static let onStart = UpdateOptions(rawValue: 1 << 0)
-    public static let onDidBecomeActive = UpdateOptions(rawValue: 1 << 1)
+    public static let onDidBecomeActive = UpdateOptions(rawValue: 2 << 1)
+    public static let never = UpdateOptions(rawValue: 2 << 2)
 }
 
 public struct Configuration {

--- a/NStackSDK/NStackSDK/Classes/NStack Manager/NStack.swift
+++ b/NStackSDK/NStackSDK/Classes/NStack Manager/NStack.swift
@@ -125,7 +125,8 @@ public class NStack {
 
         // Update if necessary and launch options doesn't contain a key present in avoid update list
         if configuration.updateOptions.contains(.onStart) &&
-            launchOptions?.keys.contains(where: { self.avoidUpdateList.contains($0) }) != true {
+            launchOptions?.keys.contains(where: { self.avoidUpdateList.contains($0) }) != true &&
+            !configuration.updateOptions.contains(.never) {
             update()
         }
     }


### PR DESCRIPTION
Right now its not possible to configure NStack without an integration with a NStack app. In order to do this with this fix one needs to set UpdateOptions.never on the configuration object and pass that to the start method.